### PR TITLE
feat/add peekchar for longer operators

### DIFF
--- a/src/lexer.zig
+++ b/src/lexer.zig
@@ -26,34 +26,13 @@ pub const Lexer = struct {
 
     fn init(input: []const u8, allocator: Allocator) !Lexer {
         var identLookup = std.StringHashMap(TokenType).init(allocator);
-        const fn_insert = try identLookup.getOrPut("fn");
-        if (!fn_insert.found_existing) {
-            fn_insert.value_ptr.* = .FUNCTION;
-        }
-        const let_insert = try identLookup.getOrPut("let");
-        if (!let_insert.found_existing) {
-            let_insert.value_ptr.* = .LET;
-        }
-        const true_insert = try identLookup.getOrPut("true");
-        if (!true_insert.found_existing) {
-            true_insert.value_ptr.* = .TRUE;
-        }
-        const false_insert = try identLookup.getOrPut("false");
-        if (!false_insert.found_existing) {
-            false_insert.value_ptr.* = .FALSE;
-        }
-        const if_insert = try identLookup.getOrPut("if");
-        if (!if_insert.found_existing) {
-            if_insert.value_ptr.* = .IF;
-        }
-        const else_insert = try identLookup.getOrPut("else");
-        if (!else_insert.found_existing) {
-            else_insert.value_ptr.* = .ELSE;
-        }
-        const return_insert = try identLookup.getOrPut("return");
-        if (!return_insert.found_existing) {
-            return_insert.value_ptr.* = .RETURN;
-        }
+        try identLookup.put("fn", .FUNCTION);
+        try identLookup.put("let", .LET);
+        try identLookup.put("true", .TRUE);
+        try identLookup.put("false", .FALSE);
+        try identLookup.put("if", .IF);
+        try identLookup.put("else", .ELSE);
+        try identLookup.put("return", .RETURN);
 
         var lexer = Lexer{
             .input = input,
@@ -102,18 +81,18 @@ pub const Lexer = struct {
                     break :bangBlock Token.new(.BANG, "!");
                 }
             },
-            '-' => Token.new(.MINUS, &[1]u8{'-'}),
-            ';' => Token.new(.SEMICOLON, &[1]u8{';'}),
-            '(' => Token.new(.LPAREN, &[1]u8{'('}),
-            ')' => Token.new(.RPAREN, &[1]u8{')'}),
-            ',' => Token.new(.COMMA, &[1]u8{','}),
-            '+' => Token.new(.PLUS, &[1]u8{'+'}),
-            '{' => Token.new(.LBRACE, &[1]u8{'{'}),
-            '}' => Token.new(.RBRACE, &[1]u8{'}'}),
-            '*' => Token.new(.ASTERISK, &[1]u8{'*'}),
-            '/' => Token.new(.SLASH, &[1]u8{'/'}),
-            '<' => Token.new(.LT, &[1]u8{'<'}),
-            '>' => Token.new(.GT, &[1]u8{'>'}),
+            '-' => Token.new(.MINUS, "-"),
+            ';' => Token.new(.SEMICOLON, ";"),
+            '(' => Token.new(.LPAREN, "("),
+            ')' => Token.new(.RPAREN, ")"),
+            ',' => Token.new(.COMMA, ","),
+            '+' => Token.new(.PLUS, "+"),
+            '{' => Token.new(.LBRACE, "{"),
+            '}' => Token.new(.RBRACE, "}"),
+            '*' => Token.new(.ASTERISK, "*"),
+            '/' => Token.new(.SLASH, "/"),
+            '<' => Token.new(.LT, "<"),
+            '>' => Token.new(.GT, ">"),
             0 => Token.new(.EOF, ""),
             else => {
                 if (isLetter(self.character)) {

--- a/src/lexer.zig
+++ b/src/lexer.zig
@@ -85,7 +85,7 @@ pub const Lexer = struct {
         self.skipWhiteSpace();
         const currentToken = switch (self.character) {
             // this was self.character on the right side of the =>, but it was not working for some reason
-            '=' => Token.new(.EQ, &[1]u8{'='}),
+            '=' => Token.new(.ASSIGN, &[1]u8{'='}),
             '-' => Token.new(.MINUS, &[1]u8{'-'}),
             ';' => Token.new(.SEMICOLON, &[1]u8{';'}),
             '(' => Token.new(.LPAREN, &[1]u8{'('}),
@@ -186,7 +186,7 @@ test "lexer reads one token" {
     var lexer = try Lexer.init(input, testAllocator);
     defer lexer.deinit();
     const tokens = [_]Token{
-        Token.new(.EQ, "="),
+        Token.new(.ASSIGN, "="),
         Token.new(.EOF, ""),
     };
     try testing.expectEqual(tokens.len, 2);
@@ -207,7 +207,7 @@ test "lexer reads the initial tokens" {
     var lexer = try Lexer.init(input, testAllocator);
     defer lexer.deinit();
     const tokens = [_]Token{
-        Token.new(.EQ, "="),
+        Token.new(.ASSIGN, "="),
         Token.new(.PLUS, "+"),
         Token.new(.LPAREN, "("),
         Token.new(.RPAREN, ")"),
@@ -233,7 +233,7 @@ test "lexer reads next tokens with multiple chars" {
     const tokens = [_]Token{
         Token.new(.LET, "let"),
         Token.new(.IDENT, "five"),
-        Token.new(.EQ, "="),
+        Token.new(.ASSIGN, "="),
         Token.new(.INT, "5"),
         Token.new(.SEMICOLON, ";"),
         Token.new(.EOF, ""),
@@ -261,17 +261,17 @@ test "lexer reads simple assignment expression" {
     const tokens = [_]Token{
         Token.new(.LET, "let"),
         Token.new(.IDENT, "five"),
-        Token.new(.EQ, "="),
+        Token.new(.ASSIGN, "="),
         Token.new(.INT, "5"),
         Token.new(.SEMICOLON, ";"),
         Token.new(.LET, "let"),
         Token.new(.IDENT, "ten"),
-        Token.new(.EQ, "="),
+        Token.new(.ASSIGN, "="),
         Token.new(.INT, "10"),
         Token.new(.SEMICOLON, ";"),
         Token.new(.LET, "let"),
         Token.new(.IDENT, "add"),
-        Token.new(.EQ, "="),
+        Token.new(.ASSIGN, "="),
         Token.new(.FUNCTION, "fn"),
         Token.new(.LPAREN, "("),
         Token.new(.IDENT, "x"),
@@ -287,7 +287,7 @@ test "lexer reads simple assignment expression" {
         Token.new(.SEMICOLON, ";"),
         Token.new(.LET, "let"),
         Token.new(.IDENT, "result"),
-        Token.new(.EQ, "="),
+        Token.new(.ASSIGN, "="),
         Token.new(.IDENT, "add"),
         Token.new(.LPAREN, "("),
         Token.new(.IDENT, "five"),
@@ -322,23 +322,25 @@ test "lexer reads simple assignment expression and some standalone mathematical 
         \\} else {
         \\    return false;
         \\}
+        \\10 == 10;
+        \\10 != 9;
     ;
     var lexer = try Lexer.init(input, testAllocator);
     defer lexer.deinit();
     const tokens = [_]Token{
         Token.new(.LET, "let"),
         Token.new(.IDENT, "five"),
-        Token.new(.EQ, "="),
+        Token.new(.ASSIGN, "="),
         Token.new(.INT, "5"),
         Token.new(.SEMICOLON, ";"),
         Token.new(.LET, "let"),
         Token.new(.IDENT, "ten"),
-        Token.new(.EQ, "="),
+        Token.new(.ASSIGN, "="),
         Token.new(.INT, "10"),
         Token.new(.SEMICOLON, ";"),
         Token.new(.LET, "let"),
         Token.new(.IDENT, "add"),
-        Token.new(.EQ, "="),
+        Token.new(.ASSIGN, "="),
         Token.new(.FUNCTION, "fn"),
         Token.new(.LPAREN, "("),
         Token.new(.IDENT, "x"),
@@ -354,7 +356,7 @@ test "lexer reads simple assignment expression and some standalone mathematical 
         Token.new(.SEMICOLON, ";"),
         Token.new(.LET, "let"),
         Token.new(.IDENT, "result"),
-        Token.new(.EQ, "="),
+        Token.new(.ASSIGN, "="),
         Token.new(.IDENT, "add"),
         Token.new(.LPAREN, "("),
         Token.new(.IDENT, "five"),
@@ -391,6 +393,14 @@ test "lexer reads simple assignment expression and some standalone mathematical 
         Token.new(.FALSE, "false"),
         Token.new(.SEMICOLON, ";"),
         Token.new(.RBRACE, "}"),
+        Token.new(.IDENT, "10"),
+        Token.new(.EQ, "=="),
+        Token.new(.INT, "10"),
+        Token.new(.SEMICOLON, ";"),
+        Token.new(.INT, "10"),
+        Token.new(.NEQ, "!="),
+        Token.new(.INT, "9"),
+        Token.new(.SEMICOLON, ";"),
         Token.new(.EOF, ""),
     };
 

--- a/src/token.zig
+++ b/src/token.zig
@@ -17,6 +17,7 @@ pub const TokenType = enum {
 
     // Operators
     EQ,
+    NEQ,
     PLUS,
     MINUS,
     BANG,


### PR DESCRIPTION
- **fix: resolve eq != assign parsing**
- **chore: add lookahead for neq and eq**
- **chore: simplify token literal expressions**
